### PR TITLE
Update Elasticsearch to resolve startup issue with 17.06

### DIFF
--- a/elk-docker-compose.yml
+++ b/elk-docker-compose.yml
@@ -6,7 +6,7 @@ services:
     command: elasticsearch -Enetwork.host=0.0.0.0 -Ediscovery.zen.ping.unicast.hosts=elasticsearch
     environment:
       ES_JAVA_OPTS: -Xms1g -Xmx1g
-    image: elasticsearch:5.2
+    image: elasticsearch:5
     ulimits:
       memlock: -1
       nofile:

--- a/journalbeat-docker-compose.yml
+++ b/journalbeat-docker-compose.yml
@@ -7,7 +7,7 @@ services:
        networks:
         - journalbeat
        volumes:
-        - /run/log/journal:/run/log/journal:ro
+        - /var/log/journal:/run/log/journal:ro
         - /etc/machine-id:/etc/machine-id:ro
        deploy:
         mode: global

--- a/journalbeat-docker-compose.yml
+++ b/journalbeat-docker-compose.yml
@@ -7,7 +7,7 @@ services:
        networks:
         - journalbeat
        volumes:
-        - /var/log/journal:/run/log/journal:ro
+        - /run/log/journal:/run/log/journal:ro
         - /etc/machine-id:/etc/machine-id:ro
        deploy:
         mode: global

--- a/journalbeat-docker-compose.yml
+++ b/journalbeat-docker-compose.yml
@@ -7,7 +7,7 @@ services:
        networks:
         - journalbeat
        volumes:
-        - /var/log/journal:/run/log/journal:ro
+        - /var/log/journal:/var/log/journal:ro
         - /etc/machine-id:/etc/machine-id:ro
        deploy:
         mode: global

--- a/journalbeat-docker-compose.yml
+++ b/journalbeat-docker-compose.yml
@@ -7,7 +7,7 @@ services:
        networks:
         - journalbeat
        volumes:
-        - /var/log/journal:/var/log/journal:ro
+        - /var/log/journal:/run/log/journal:ro
         - /etc/machine-id:/etc/machine-id:ro
        deploy:
         mode: global


### PR DESCRIPTION
I don't think this was intentional, but when starting up on 17.06, I currently get elastic search to fail startup with the following message:

```
[2018-09-25T16:14:14,789][WARN ][o.e.b.ElasticsearchUncaughtExceptionHandler] [] uncaught exception in thread [main]
org.elasticsearch.bootstrap.StartupException: java.lang.IllegalStateException: No match found
	at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:125) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:112) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.cli.SettingCommand.execute(SettingCommand.java:54) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:122) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.cli.Command.main(Command.java:88) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:89) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:82) ~[elasticsearch-5.2.2.jar:5.2.2]
Caused by: java.lang.IllegalStateException: No match found
	at java.util.regex.Matcher.group(Matcher.java:536) ~[?:1.8.0_121]
	at org.elasticsearch.monitor.os.OsProbe.getControlGroups(OsProbe.java:216) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.monitor.os.OsProbe.getCgroup(OsProbe.java:414) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.monitor.os.OsProbe.osStats(OsProbe.java:466) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.monitor.os.OsService.<init>(OsService.java:45) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.monitor.MonitorService.<init>(MonitorService.java:45) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.node.Node.<init>(Node.java:345) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.node.Node.<init>(Node.java:232) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.bootstrap.Bootstrap$6.<init>(Bootstrap.java:241) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:241) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:333) ~[elasticsearch-5.2.2.jar:5.2.2]
	at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:121) ~[elasticsearch-5.2.2.jar:5.2.2]
	... 6 more
```
It looks like this is a manifestation of https://github.com/elastic/elasticsearch/issues/23218

So this PR bumps to elasticsearch:5, which seems to resolve the startup issue just fine.

